### PR TITLE
fix rounding for the y-coordinate

### DIFF
--- a/functions.lua
+++ b/functions.lua
@@ -473,7 +473,7 @@ function travelpoints.get_location(name)
 
 	-- Round down values and adjust.
 	pos.x = math.floor(pos.x + 0.5)
-	pos.y = math.floor(pos.y + 0.5)
+	pos.y = math.floor(pos.y) + 0.5
 	pos.z = math.floor(pos.z + 0.5)
 
 	return pos


### PR DESCRIPTION
on minetest 0.4.16 i noticed when traveling to a gravel block, i could not start walking without jumping up a little bit first.

the issue seems to be that when you are standing _on_ the center of a block, the `/tpset` command creates a travelpoint _in the middle_ of the block, so the y-coordinate is `.5` less than it should be.